### PR TITLE
Fetch status from either headers or trailers

### DIFF
--- a/lib/grpc-async/client.ml
+++ b/lib/grpc-async/client.ml
@@ -56,7 +56,7 @@ let call ~service ~rpc ?(scheme = "https") ~handler ~do_request
       | _ ->
           Ivar.fill out_ivar (Error (Grpc.Status.v Grpc.Status.Unknown));
           return ());
-    don't_wait_for @@ return @@ trailers_handler response.headers
+    don't_wait_for (return (trailers_handler response.headers))
   in
   let write_body : [ `write ] H2.Body.t =
     do_request ?trailers_handler:(Some trailers_handler) request
@@ -70,7 +70,8 @@ let call ~service ~rpc ?(scheme = "https") ~handler ~do_request
   let%bind trailers_status =
     (* In case no grpc-status appears in headers or trailers. *)
     if Ivar.is_full trailers_status_ivar then Ivar.read trailers_status_ivar
-    else return (Grpc.Status.v ~message:"Server did not return grpc-status" Grpc.Status.Unknown) 
+    else return (
+      Grpc.Status.v ~message:"Server did not return grpc-status" Grpc.Status.Unknown) 
   in
   match out with
   | Error _ as e -> return e

--- a/lib/grpc-async/client.ml
+++ b/lib/grpc-async/client.ml
@@ -25,18 +25,6 @@ let call ~service ~rpc ?(scheme = "https") ~handler ~do_request
   let read_body_ivar = Ivar.create () in
   let handler_res_ivar = Ivar.create () in
   let out_ivar = Ivar.create () in
-  let response_handler (response : H2.Response.t) (body : [ `read ] H2.Body.t) =
-    Ivar.fill read_body_ivar body;
-    don't_wait_for
-      (match response.status with
-      | `OK ->
-          let%bind handler_res = Ivar.read handler_res_ivar in
-          Ivar.fill out_ivar (Ok handler_res);
-          return ()
-      | _ ->
-          Ivar.fill out_ivar (Error (Grpc.Status.v Grpc.Status.Unknown));
-          return ())
-  in
   let trailers_status_ivar = Ivar.create () in
   let trailers_handler headers =
     let code =
@@ -49,10 +37,26 @@ let call ~service ~rpc ?(scheme = "https") ~handler ~do_request
     in
     match code with
     | None -> ()
-    | Some code ->
-        let message = H2.Headers.get headers "grpc-message" in
-        let status = Grpc.Status.v ?message code in
-        Ivar.fill trailers_status_ivar status
+    | Some code -> 
+        match Ivar.is_empty trailers_status_ivar with 
+        | true -> 
+          let message = H2.Headers.get headers "grpc-message" in
+          let status = Grpc.Status.v ?message code in
+          Ivar.fill trailers_status_ivar status
+        | _ -> (* This should never happen, but just in case. *) ()
+  in
+  let response_handler (response : H2.Response.t) (body : [ `read ] H2.Body.t) =
+    Ivar.fill read_body_ivar body;
+    don't_wait_for
+      (match response.status with
+      | `OK ->
+          let%bind handler_res = Ivar.read handler_res_ivar in
+          Ivar.fill out_ivar (Ok handler_res);
+          return ()
+      | _ ->
+          Ivar.fill out_ivar (Error (Grpc.Status.v Grpc.Status.Unknown));
+          return ());
+    don't_wait_for @@ return @@ trailers_handler response.headers
   in
   let write_body : [ `write ] H2.Body.t =
     do_request ?trailers_handler:(Some trailers_handler) request
@@ -63,15 +67,7 @@ let call ~service ~rpc ?(scheme = "https") ~handler ~do_request
      Ivar.fill handler_res_ivar handler_res;
      return ());
   let%bind out = Ivar.read out_ivar in
-  let%bind trailers_status =
-    (* trailers_status_ivar is not always filled at this point, because
-     * trailers_handler is not always called. Perhaps because there are no
-     * trailers in some cases?  For one example, it happens in lnd when
-     * QueryRoutes returns an empty list.  In this case, we let the call return
-     * with an unknown status. *)
-    if Ivar.is_full trailers_status_ivar then Ivar.read trailers_status_ivar
-    else return (Grpc.Status.v Grpc.Status.Unknown)
-  in
+  let%bind trailers_status = Ivar.read trailers_status_ivar in
   match out with
   | Error _ as e -> return e
   | Ok out -> return (Ok (out, trailers_status))

--- a/lib/grpc-lwt/client.ml
+++ b/lib/grpc-lwt/client.ml
@@ -65,10 +65,10 @@ let call ~service ~rpc ?(scheme = "https") ~handler ~do_request
       Lwt.wakeup_later handler_res_notify handler_res);
   let* out in
   let+ status = 
-    match Lwt.state status with 
+    match Lwt.is_sleeping status with 
     (* In case no grpc-status appears in headers or trailers. *)
-    | Sleep -> let+ status in status
-    | _ -> Lwt.return @@ Grpc.Status.v ~message:"Server did not return grpc-status" Grpc.Status.Unknown
+    | false -> let+ status in status
+    | true -> Lwt.return @@ Grpc.Status.v ~message:"Server did not return grpc-status" Grpc.Status.Unknown
   in
   match out with Error _ as e -> e | Ok out -> Ok (out, status)
 

--- a/lib/grpc-lwt/client.ml
+++ b/lib/grpc-lwt/client.ml
@@ -54,7 +54,7 @@ let call ~service ~rpc ?(scheme = "https") ~handler ~do_request
         else
           let+ handler_res in
           Lwt.wakeup_later out_notify (Ok handler_res));
-    Lwt.async(fun () -> Lwt.return @@ trailers_handler response.headers)
+    Lwt.async(fun () -> Lwt.return (trailers_handler response.headers))
   in
   let write_body =
     do_request ?trailers_handler:(Some trailers_handler) request
@@ -67,8 +67,9 @@ let call ~service ~rpc ?(scheme = "https") ~handler ~do_request
   let+ status = 
     match Lwt.is_sleeping status with 
     (* In case no grpc-status appears in headers or trailers. *)
-    | false -> let+ status in status
-    | true -> Lwt.return @@ Grpc.Status.v ~message:"Server did not return grpc-status" Grpc.Status.Unknown
+    | false -> status
+    | true -> Lwt.return (
+      Grpc.Status.v ~message:"Server did not return grpc-status" Grpc.Status.Unknown)
   in
   match out with Error _ as e -> e | Ok out -> Ok (out, status)
 

--- a/lib/grpc-lwt/client.ml
+++ b/lib/grpc-lwt/client.ml
@@ -24,17 +24,6 @@ let call ~service ~rpc ?(scheme = "https") ~handler ~do_request
   let read_body, read_body_notify = Lwt.wait () in
   let handler_res, handler_res_notify = Lwt.wait () in
   let out, out_notify = Lwt.wait () in
-  let response_handler (response : H2.Response.t) body =
-    Lwt.wakeup_later read_body_notify body;
-    Lwt.async (fun () ->
-        if response.status <> `OK then (
-          Lwt.wakeup_later out_notify
-            (Error (Grpc.Status.v Grpc.Status.Unknown));
-          Lwt.return_unit)
-        else
-          let+ handler_res in
-          Lwt.wakeup_later out_notify (Ok handler_res))
-  in
   let status, status_notify = Lwt.wait () in
   let trailers_handler headers =
     let code =
@@ -48,9 +37,24 @@ let call ~service ~rpc ?(scheme = "https") ~handler ~do_request
     match code with
     | None -> ()
     | Some code ->
-        let message = H2.Headers.get headers "grpc-message" in
-        let status = Grpc.Status.v ?message code in
-        Lwt.wakeup_later status_notify status
+        match Lwt.state status with 
+        | Sleep -> 
+          let message = H2.Headers.get headers "grpc-message" in
+          let status = Grpc.Status.v ?message code in
+          Lwt.wakeup_later status_notify status
+        | _ -> (* This should never happen, but just in case. *) ()
+  in
+  let response_handler (response : H2.Response.t) body =
+    Lwt.wakeup_later read_body_notify body;
+    Lwt.async (fun () ->
+        if response.status <> `OK then (
+          Lwt.wakeup_later out_notify
+            (Error (Grpc.Status.v Grpc.Status.Unknown));
+          Lwt.return_unit)
+        else
+          let+ handler_res in
+          Lwt.wakeup_later out_notify (Ok handler_res));
+    Lwt.async(fun () -> Lwt.return @@ trailers_handler response.headers)
   in
   let write_body =
     do_request ?trailers_handler:(Some trailers_handler) request


### PR DESCRIPTION
Closes https://github.com/dialohq/ocaml-grpc/issues/1 for Lwt & Async.

In summary, to deal with "trailers-only" responses, we apply `trailers_handler` also to the headers. This seems to successfully solve the situation in which some calls hang, as reported in https://github.com/dialohq/ocaml-grpc-fork/pull/2.

Although we should reasonably assume that a response will not contain `grpc-status` in both headers and trailers, in the unlikely event that a server has this behaviour, no exception will be raised. However, only one status will be recorded. 

In the event that there is no status at all, the call can still hang. However, this is unlikely.